### PR TITLE
Fix links to PLN docs

### DIFF
--- a/docs/protocol-labs-network/about.md
+++ b/docs/protocol-labs-network/about.md
@@ -42,12 +42,12 @@ Protocol Labs drives breakthroughs in computing to push humanity forward.
 
 ## Sections | The Protocol Labs Network
 
-1. [What is the PL Network?](protocol-labs-network/what-is-pl.md)
-2. [Teams in the PL Network](protocol-labs-network/teams-in-pl.md)
-3. [Where we are Headed](protocol-labs-network/where-we-headed.md)
-4. [Protocol Labs Culture](protocol-labs-network/pl-culture.md)
-4. [Open Source Stewardship](protocol-labs-network/os-stewardship.md)
-5. [Open Source Contributions](protocol-labs-network/os-contributing.md)
+1. [What is the PL Network?](./what-is-pl.md)
+2. [Teams in the PL Network](./teams-in-pl.md)
+3. [Where we are Headed](./where-we-headed.md)
+4. [Protocol Labs Culture](./pl-culture.md)
+4. [Open Source Stewardship](./os-stewardship.md)
+5. [Open Source Contributions](./os-contributing.md)
 
 
 #### Links


### PR DESCRIPTION
The previous path yielded invalid links: https://github.com/protocol/launchpad/blob/main/docs/protocol-labs-network/protocol-labs-network/what-is-pl.md. I think this fixes this.