### PR TITLE
Br filecoin cryptoeconnomics

### DIFF
--- a/content/en/curriculum/filecoin/cryptoeconomics/index.md
+++ b/content/en/curriculum/filecoin/cryptoeconomics/index.md
@@ -38,8 +38,8 @@ In this 6 minute video, understand how Filecoin proves both replication, retriev
 
 ### [Storage Providers (Miners)](https://docs.filecoin.io/storage-provider/how-providing-works)
 
-* Anyone with the [minimum required hardware](https://docs.filecoin.io/storage-provider/hardware-requirements/) can create a storage miner
-* Miners do not earn rewards until they onboard a minimum amount of sealed storage to the network
+* Anyone with the [minimum required hardware](https://docs.filecoin.io/storage-provider/hardware-requirements/) can create a storage Storage Provider
+* Storage Providers do not earn rewards until they onboard a minimum amount of sealed storage to the network
 * Deals are made trustlessly between a client and a provider
 * There are incentive structures such as _power_ that allow providers to earn Filecoin through _storage fees_ and _block rewards_. [More on provider rewards](https://docs.filecoin.io/storage-provider/storage-provider-rewards/#storage-fees)
 
@@ -49,8 +49,8 @@ There are several special mechanisms that the Filecoin blockchain implements, su
 The Filecoin network uses upfront token collaterals, like those used in other proof-of-stake protocols, proportional to the storage hardware committed. Storage providers are give something called _power_ which increases their likelihood of winning block rewards, and their contribution to consensus. There are three types of collateral that Filecoin providers must provide in order to participate in the economy:
 
 * **Initial Pledge Collateral** – This consists of a storage pledge and a consensus pledge. The storage pledge provides tokens as a collateral that will be slashed if storage sectors are terminated, and the consensus pledge provides a mechanism for preventing consensus takeovers.
-* **Block Reward as Collateral** – Filecoin penalizes miners that fail to store files for the promised duration, balancing it with an overly high cost to join the network. Block rewards earned by a miner are slashed if a sector is terminated before its expiration.
-* **Storage Provider Deal Collateral** – Miners can offer a higher deal collateral to data providers (above the minimum specified by the protocol), implying a higher level of service and reliability. Given the increased stakes, clients may associate collateral beyond the minimum with an increased likelihood that their data will be reliably stored. This is returned to storage providers once sectors expire.
+* **Block Reward as Collateral** – Filecoin penalizes Storage Providers that fail to store files for the promised duration, balancing it with an overly high cost to join the network. Block rewards earned by a Storage Providers are slashed if a sector is terminated before its expiration.
+* **Storage Provider Deal Collateral** – Storage Providers can offer a higher deal collateral to data providers (above the minimum specified by the protocol), implying a higher level of service and reliability. Given the increased stakes, clients may associate collateral beyond the minimum with an increased likelihood that their data will be reliably stored. This is returned to storage providers once sectors expire.
 
 ### Verified Data Providers
 Using a network of verifiers, those who are storing data can apply to have their data categorized as verified (valuable) data. Once a data client is verified, they are given DataCap for a certain amount of approved data, that, when stored, rewards the storage provider with more power.

--- a/content/en/curriculum/filecoin/cryptoeconomics/index.md
+++ b/content/en/curriculum/filecoin/cryptoeconomics/index.md
@@ -38,7 +38,7 @@ In this 6 minute video, understand how Filecoin proves both replication, retriev
 
 ### [Storage Providers (Miners)](https://docs.filecoin.io/storage-provider/how-providing-works)
 
-* Anyone with the [minimum required hardware](https://docs.filecoin.io/storage-provider/hardware-requirements/) can create a storage Storage Provider
+* Anyone with the [minimum required hardware](https://docs.filecoin.io/storage-provider/hardware-requirements/) can be a storage Storage Provider
 * Storage Providers do not earn rewards until they onboard a minimum amount of sealed storage to the network
 * Deals are made trustlessly between a client and a provider
 * There are incentive structures such as _power_ that allow providers to earn Filecoin through _storage fees_ and _block rewards_. [More on provider rewards](https://docs.filecoin.io/storage-provider/storage-provider-rewards/#storage-fees)

--- a/content/en/curriculum/filecoin/how-filecoin-works/index.md
+++ b/content/en/curriculum/filecoin/how-filecoin-works/index.md
@@ -76,7 +76,7 @@ Executing messages, for example by including transactions or proofs in the chain
 * **_Overestimation burn_**: an additional amount of gas to burn that grows larger when the difference between _GasLimit_ and _GasUsage_ is large. (See [current implementation](https://github.com/filecoin-project/lotus/blob/v0.10.0/chain/vm/burn.go#L38)).
 
 ### [Actors](https://docs.filecoin.io/about-filecoin/how-filecoin-works/#actors)
-Actors are a [software design pattern](https://en.wikipedia.org/wiki/Actor_model) for managing state. Accounts, Multisigs, Miners, and anything with a state, such as an account balance, are implemented as an _actor_.
+Actors are a [software design pattern](https://en.wikipedia.org/wiki/Actor_model) for managing state. Accounts, Multisigs, Storage Providers, and anything with a state, such as an account balance, are implemented as an _actor_.
 
 ### [Addresses](https://docs.filecoin.io/about-filecoin/how-filecoin-works/#addresses)
 In Filecoin, addresses are used to identify actors. There are 4 address types:
@@ -89,7 +89,7 @@ In Filecoin, addresses are used to identify actors. There are 4 address types:
 ### [Filecoin Plus](https://plus.fil.org/)
 Filecion Plus is a mechanism for onboarding data into the Filecoin market that incentivizes the storage providers on the Filecoin network to store real, valuable, and usable data. It is a layer of social trust on top of the Filecoin Network to help incentivize this storage. Storage providers who store data that has been approved for DataCap have more power to win block rewards. The [Filecoin Plus Dashboard](https://filplus.info/) provides data about verification, storage, and more.
 
-There are a few ways one can get [approved to store data](https://plus.fil.org/landing) on the Filecoin network, and there are [governance processes and roles](https://github.com/filecoin-project/notary-governance), including root key-holders, notaries, clients, and miners who interact through the allocation and spending of DataCap, and help onboard that data to the network.
+There are a few ways one can get [approved to store data](https://plus.fil.org/landing) on the Filecoin network, and there are [governance processes and roles](https://github.com/filecoin-project/notary-governance), including root key-holders, notaries, clients, and storage providers who interact through the allocation and spending of DataCap, and help onboard that data to the network.
 
 ![Filcoin Plus Governance](notary.png)
 

--- a/content/en/curriculum/filecoin/introduction/index.md
+++ b/content/en/curriculum/filecoin/introduction/index.md
@@ -40,13 +40,13 @@ _Filecoin is a data storage and retrieval marketplace that coordinates untrusted
 
 * **Verifiable storage** – Rather than needing to trust a cloud storage provider or rely on
 legal recourse, the Filecoin Protocol cryptographically verifies data storage.
-* **Open participation** – Anyone with sufficient hardware and an internet connection can be a stroage provider (and Filecoin miner) for the Filecoin Network.
+* **Open participation** – Anyone with sufficient hardware and an internet connection can be a stroage provider (Filecoin miner) for the Filecoin Network.
 * **Empowers local optimization** – Driven by open participation, market forces will enable more efficient and distributed data storage and communication than centralized storage platforms. The distributed network allows for a more local and resilient architecture and data availability.
 * **Flexible storage options** – As an open platform, the network has the flexibility for the creation & disseminations of tools and services provided by the community of developers improving and building on the protocol.
 * **A community network** – Filecoin provides participants the opportunity to have stake in the networkʼs success. Participants in the network benefit by working together to improve the Filecoin network as a whole.
 
 #### The Filecoin Economy
-Filecoin is more than a network; the protocol and infrastructure lays the groundwork for an economy built around a marketplace for the storage and retrieval of data. The growth of the network depends upon collaboration between researchers, engineers, stakeholders, miners, and clients in a market economy, as the network adapts and grows to accommodate additional use cases.
+Filecoin is more than a network; the protocol and infrastructure lays the groundwork for an economy built around a marketplace for the storage and retrieval of data. The growth of the network depends upon collaboration between researchers, engineers, stakeholders, storage providers, and clients in a market economy, as the network adapts and grows to accommodate additional use cases.
 
 The Filecoin token acts as a medium of exchange, facilitating transactions and production activities, somewhat similar to the in-game currencies of virtual economies in multiplayer online games. In addition, as a currency, the token also acts as a store of value; its minting is tied to adding utility in the form of data storage and other services to the network.
 


### PR DESCRIPTION
## Problem

the `Filecoin Cryptoeconomics` specifically states the following:

```
For most blockchain protocols, miners are incentivized to do work that record ledger transactions and 
do the proof of work required to move the blockchain forward. Filecoin is different in how it requires
providers to do both this, as well as provide immutable storage for the network, which is why we 
call them **Storage Providers** instead of miners.
```

the term `miner` is used around the content before and after this statement which can be more confusing than just referencing it as `storage provider`

## Solution

change instances of `miner` to `storage provider` - any reference to `miner` is secondary and referenced as `storage provider (miner)`