### PR TITLE
Fix markdown formatting in "Other issue" template

### DIFF
--- a/.github/ISSUE_TEMPLATE/-other-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/-other-issue-template.md
@@ -7,11 +7,11 @@ assignees: ''
 
 ---
 
-** Describe the use case**
- What were you trying to do?
+**Describe the use case**
+<!-- What were you trying to do? -->
 
-** Describe the problem**
-What issue are you trying to solve
+**Describe the problem**
+<!-- What issue are you trying to solve -->
 
 **Proposed Solution**
-How can this Problem be solved?
+<!-- How can this Problem be solved? -->


### PR DESCRIPTION
- Remove extra space after `**` to render the heading in bold font.
- Wrap instructions in HTML comments to hide them from the rendered markdown.