### PR TITLE
Fix IPLD Vector implementation example

### DIFF
--- a/content/en/curriculum/ipld/distributed-data-structures.md
+++ b/content/en/curriculum/ipld/distributed-data-structures.md
@@ -125,7 +125,7 @@ class SuperLargeArrayBlock {
       const childIndex = Math.floor(index / (width ** (this.height - 1)))
       const newIndex = index % (width ** (this.height - 1))
       // load and traverse into a child
-      return this.getChildAt(childIndex).getElementAt(index)
+      return this.getChildAt(childIndex).getElementAt(newIndex)
     }
     // read directly from this node's data array
     return this.elements[index]


### PR DESCRIPTION
The text says:

> But note that we can’t pass the original index value down
> to that child because it only knows about the graph below it,
> so we essentially remove part of the index value that is not
> relevant to the child and pass that on.

The code calls `getElementAt(index)`, contradicting the explanation.

In this pull request, I changed to code to call `getElementAt(newIndex)` instead.

Before my change, the variable `newIndex` was set but never read.

/cc @rvagg: Can you PTAL? I saw you had presented this code snippet in the Youtube video [ResNetLab: Elective Course Module - InterPlanetary Linked Data (IPLD)](https://www.youtube.com/watch?v=Sgf6j_mCdjI).