### PR TITLE
Removed hugo-debugprint theme

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -8,7 +8,7 @@ enableRobotsTXT = true
 languageCode = "en-US"
 paginate = 7
 rssLimit = 10
-theme = ["hugo-debugprint"]
+theme = []
 
 # Multilingual
 defaultContentLanguage = "en"


### PR DESCRIPTION
Removing unnecessary hugo theme that is causing an error in production deployment